### PR TITLE
fix PC regex breaking immediate parsing

### DIFF
--- a/src/com/cburch/logisim/Main.java
+++ b/src/com/cburch/logisim/Main.java
@@ -92,7 +92,7 @@ public class Main {
 	final static Logger logger = LoggerFactory.getLogger(Main.class);
 
 	// Updated 2/19/2019 - Akhil Bhandaru for P2
-	public static final LogisimVersion VERSION = LogisimVersion.get(2, 14, 7, 4);
+	public static final LogisimVersion VERSION = LogisimVersion.get(2, 14, 7, 5);
 
 	public static final String VERSION_NAME = VERSION.toString();
 	public static final int COPYRIGHT_YEAR = 2018;

--- a/src/edu/cornell/cs3410/ProgramAssembler.java
+++ b/src/edu/cornell/cs3410/ProgramAssembler.java
@@ -195,7 +195,7 @@ public class ProgramAssembler {
                                                                                                           // risc-v
                                                                                                           // register
                                                                                                           // names
-    static String __pc = "(pc|PC)";
+    static String __pc = "(?:pc|PC)";
     static String __hex = "0x[a-fA-F0-9]+";
     static String __decimal = "-?\\d+";
     static String __label = "[a-zA-Z]\\w*";


### PR DESCRIPTION
Bumped the version so autoupdate can send out the bugfix once it gets set up
Not 100% sure if this causes any regressions--depends on if anything was using the match group (pc|PC), which doesn't seem to be the case.