### PR TITLE
Add batch change attributes feature

### DIFF
--- a/src/com/cburch/logisim/circuit/SplitterAttributes.java
+++ b/src/com/cburch/logisim/circuit/SplitterAttributes.java
@@ -368,6 +368,7 @@ class SplitterAttributes extends AbstractAttributeSet {
 			appear = appearance;
 			parameters = null;
 		} else if (attr instanceof BitOutAttribute) {
+
 			BitOutAttribute bitOutAttr = (BitOutAttribute) attr;
 			int val;
 			if (value instanceof Integer) {

--- a/src/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/com/cburch/logisim/gui/generic/AttrTable.java
@@ -64,6 +64,12 @@ import javax.swing.event.TableModelListener;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableModel;
 
+import javax.swing.JPopupMenu;
+import javax.swing.JMenuItem;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.AbstractAction;
+
 import com.bfh.logisim.hdlgenerator.HDLColorRenderer;
 import com.cburch.logisim.prefs.AppPreferences;
 import com.cburch.logisim.util.JDialogOk;
@@ -194,7 +200,7 @@ public class AttrTable extends JPanel implements LocaleListener {
 								Strings.get("attributeChangeInvalidTitle"),
 								JOptionPane.WARNING_MESSAGE);
 					}
-					editor = null; 
+					editor = null;
 				} else if (editor instanceof JInputComponent) {
 					JInputComponent input = (JInputComponent) editor;
 					MyDialog dlog;
@@ -466,7 +472,7 @@ public class AttrTable extends JPanel implements LocaleListener {
 			return new Dimension(1, ret.height);
 		}
 	}
-	
+
 	private static final AttrTableModel NULL_ATTR_MODEL = new NullAttrModel();
 	private Window parent;
 	private boolean titleEnabled;
@@ -490,6 +496,7 @@ public class AttrTable extends JPanel implements LocaleListener {
 		table.setTableHeader(null);
 		table.setRowHeight(AppPreferences.getScaled(AppPreferences.BoxSize));
 
+		table.addMouseListener(new PopUpTrigger());
 
 		Font baseFont = title.getFont();
 		int titleSize = Math.round(baseFont.getSize() * 1.2f);
@@ -514,6 +521,46 @@ public class AttrTable extends JPanel implements LocaleListener {
 		LocaleManager.addLocaleListener(this);
 		localeChanged();
 	}
+	//=============================
+	class PopUp extends JPopupMenu {
+		JMenuItem setAll;
+		public PopUp() {
+				setAll = new JMenuItem(new AbstractAction("Set all to...") {
+				    public void actionPerformed(ActionEvent e) {
+				        String ans = JOptionPane.showInputDialog("Set to what val?");
+								if (ans == null) return;
+
+								try {
+									for(int a: table.getSelectedRows()) tableModel.attrModel.getRow(a).setValue(ans);
+								} catch (AttrTableSetException ex) {
+									JOptionPane.showMessageDialog(parent, ex.getMessage(),
+											Strings.get("attributeChangeInvalidTitle"),
+											JOptionPane.WARNING_MESSAGE);
+								}
+
+				    }
+				});
+				add(setAll);
+		}
+	}
+
+	class PopUpTrigger extends MouseAdapter {
+	    public void mousePressed(MouseEvent e) {
+	        if (e.isPopupTrigger())
+	            showPopUp(e);
+	    }
+
+	    public void mouseReleased(MouseEvent e) {
+	        if (e.isPopupTrigger())
+	            showPopUp(e);
+	    }
+
+	    private void showPopUp	(MouseEvent e) {
+	        PopUp menu = new PopUp();
+	        menu.show(e.getComponent(), e.getX(), e.getY());
+	    }
+	}
+	//=============================
 
 	public AttrTableModel getAttrTableModel() {
 		return tableModel.attrModel;

--- a/src/com/cburch/logisim/gui/generic/AttrTable.java
+++ b/src/com/cburch/logisim/gui/generic/AttrTable.java
@@ -69,6 +69,7 @@ import javax.swing.JMenuItem;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.AbstractAction;
+import com.cburch.logisim.data.Attribute;
 
 import com.bfh.logisim.hdlgenerator.HDLColorRenderer;
 import com.cburch.logisim.prefs.AppPreferences;
@@ -524,13 +525,21 @@ public class AttrTable extends JPanel implements LocaleListener {
 	//=============================
 	class PopUp extends JPopupMenu {
 		JMenuItem setAll;
-		public PopUp() {
-				setAll = new JMenuItem(new AbstractAction("Set all to...") {
+		public PopUp(final MouseEvent em) {
+				setAll = new JMenuItem(new AbstractAction("Set all selected to...") {
 				    public void actionPerformed(ActionEvent e) {
-				        String ans = JOptionPane.showInputDialog("Set to what val?");
-								if (ans == null) return;
+
+							JComboBox comboBox = (JComboBox) tableModel.attrModel.getRow(table.rowAtPoint(em.getPoint())).getEditor(parent);
+
+							Object[] content = {"Set to what val?","Currently changing " + Integer.toString(table.getSelectedRows().length) + " attributes.",comboBox};
+
+							int confirm = JOptionPane.showConfirmDialog(null,
+						    content,"Batch change",JOptionPane.OK_CANCEL_OPTION);
+
+								if (confirm == JOptionPane.CANCEL_OPTION) return;
 
 								try {
+									Object ans = comboBox.getSelectedItem();
 									for(int a: table.getSelectedRows()) tableModel.attrModel.getRow(a).setValue(ans);
 								} catch (AttrTableSetException ex) {
 									JOptionPane.showMessageDialog(parent, ex.getMessage(),
@@ -544,19 +553,29 @@ public class AttrTable extends JPanel implements LocaleListener {
 		}
 	}
 
+	public boolean arrContains(int[] arr, int n){
+		for(int i = 0; i< arr.length; i++){
+			if (arr[i]==n) return true;
+		}
+		return false;
+	}
+
 	class PopUpTrigger extends MouseAdapter {
 	    public void mousePressed(MouseEvent e) {
-	        if (e.isPopupTrigger())
-	            showPopUp(e);
+	        if (e.isPopupTrigger()){
+	            	showPopUp(e);
+						}
 	    }
 
 	    public void mouseReleased(MouseEvent e) {
-	        if (e.isPopupTrigger())
-	            showPopUp(e);
+	        if (e.isPopupTrigger()){
+	            	showPopUp(e);
+						}
 	    }
 
 	    private void showPopUp	(MouseEvent e) {
-	        PopUp menu = new PopUp();
+	        PopUp menu = new PopUp(e);
+					menu.setAll.setEnabled(arrContains(table.getSelectedRows(), table.rowAtPoint(e.getPoint())));
 	        menu.show(e.getComponent(), e.getX(), e.getY());
 	    }
 	}

--- a/src/com/cburch/logisim/gui/main/SelectionAttributes.java
+++ b/src/com/cburch/logisim/gui/main/SelectionAttributes.java
@@ -289,6 +289,7 @@ class SelectionAttributes extends AbstractAttributeSet {
 
 	@Override
 	public <V> void setValue(Attribute<V> attr, V value) {
+
 		Circuit circ = canvas.getCircuit();
 		if (selected.isEmpty() && circ != null) {
 			circ.getStaticAttributes().setValue(attr, value);


### PR DESCRIPTION
Gifs to help explain what it does because it's 3 am and I cba to write it up myself.
Before:
![ezgif-1-b27590726516](https://user-images.githubusercontent.com/18129258/55534469-87777180-5682-11e9-8a11-85a5702679c4.gif)
After:
![ezgif-1-3e72673c5ea9](https://user-images.githubusercontent.com/18129258/55534470-88a89e80-5682-11e9-9e7e-c731eff4f352.gif)

Uses the default JTable selection behavior to add batch changing attributes.

Relies on built in logisim exception handling when someone selects two or more incompatible attributes to change, which seems like it works well enough for now.

Grouping all of these actions for the purposes of ctrl-Z functionality isn't exactly there yet, but it's still usable and does what's intuitive.